### PR TITLE
[8] Adding CLI support

### DIFF
--- a/exe/rsgem
+++ b/exe/rsgem
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'rsgem'
+
+Dry::CLI.new(RSGem::CLI::Commands).call

--- a/lib/rsgem.rb
+++ b/lib/rsgem.rb
@@ -20,6 +20,10 @@ require 'rsgem/dependencies/rspec'
 require 'rsgem/dependencies/rubocop'
 require 'rsgem/dependencies/simplecov'
 require 'rsgem/context'
+require 'dry/cli'
+require 'rsgem/cli/commands/new'
+require 'rsgem/cli/commands/version'
+require 'rsgem/cli/commands'
 
 module RSGem
 end

--- a/lib/rsgem/cli/commands.rb
+++ b/lib/rsgem/cli/commands.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module RSGem
+  module CLI
+    module Commands
+      extend Dry::CLI::Registry
+
+      register 'new', New
+      register 'version', Version, aliases: ['v', '-v', '--version']
+    end
+  end
+end

--- a/lib/rsgem/cli/commands/new.rb
+++ b/lib/rsgem/cli/commands/new.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RSGem
+  module CLI
+    module Commands
+      class New < Dry::CLI::Command
+        desc 'Create a new gem'
+
+        argument :gem_name, type: :string, required: true, desc: 'Name of your new gem'
+
+        def call(gem_name:)
+          RSGem::Gem.new(gem_name: gem_name).create
+        end
+      end
+    end
+  end
+end

--- a/lib/rsgem/cli/commands/version.rb
+++ b/lib/rsgem/cli/commands/version.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module RSGem
+  module CLI
+    module Commands
+      class Version < Dry::CLI::Command
+        desc 'Print version'
+
+        def call(*)
+          puts RSGem::VERSION
+        end
+      end
+    end
+  end
+end

--- a/lib/rsgem/version.rb
+++ b/lib/rsgem/version.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 module RSGem
-  VERSION = '0.1.0'
+  MAJOR = 0
+  MINOR = 1
+  PATCH = 0
+  VERSION = [MAJOR, MINOR, PATCH].join('.')
 end

--- a/rsgem.gemspec
+++ b/rsgem.gemspec
@@ -20,9 +20,10 @@ Gem::Specification.new do |spec|
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir['LICENSE.txt', 'README.md', 'bin/**/*', 'lib/**/*']
   spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables   = ['rsgem']
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'dry-cli', '~> 0.6.0'
   spec.add_development_dependency 'pry', '~> 0.13.0'
   spec.add_development_dependency 'rake', '~> 13.0.1'
   spec.add_development_dependency 'reek', '~> 5.6.0'

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe 'CLI' do
+  describe 'rsgem version' do
+    it 'returns the version' do
+      expect(`./exe/rsgem version`.strip).to eq RSGem::VERSION
+    end
+
+    it 'returns the version using the alternative -v option' do
+      expect(`./exe/rsgem -v`.strip).to eq RSGem::VERSION
+    end
+
+    it 'returns the version using the alternative v option' do
+      expect(`./exe/rsgem v`.strip).to eq RSGem::VERSION
+    end
+
+    it 'returns the version using the alternative --version option' do
+      expect(`./exe/rsgem --version`.strip).to eq RSGem::VERSION
+    end
+  end
+
+  describe 'rsgem new NAME' do
+    after { `rm -rf #{gem_name}` }
+
+    let(:gem_name) { 'testing_cli' }
+
+    subject { `./exe/rsgem new #{gem_name}` }
+
+    it 'creates a new gem' do
+      expect(subject).to include('Reek installed')
+      expect(subject).to include('Rubocop installed')
+      expect(subject).to include('Simplecov installed')
+      expect(subject).to include('Gemfile cleaned')
+      expect(subject).to include('Gemfile.lock added to .gitignore')
+      expect(subject).to include('Rubocop:')
+      expect(File.exist?(gem_name)).to eq true
+    end
+  end
+end


### PR DESCRIPTION
Resolves #8 

- Using dry-cli
- Added an executable in the `exe` folder
- Updated gemspec to just include the `rsgem` executable
- Added the `new` and `version` commands

This CLI will look like:

```
➜ $ rsgem -h
Commands:
  rsgem new GEM_NAME           # Creates a new gem
  rsgem version                # Print version
```

```
➜ $ rsgem new -h
Command:
  rsgem new

Usage:
  rsgem new GEM_NAME

Description:
  Creates a new gem

Arguments:
  GEM_NAME              # REQUIRED Name of your new gem

Options:
  --help, -h                        # Print this help
```

```
➜ $ rsgem new sparkling_new_gem
  Rake installed
  Reek installed
  Rspec installed
  Rubocop installed
  Simplecov installed
  Gemfile cleaned
  Gemfile.lock added to .gitignore
  Rubocop:
    8 files inspected, 34 offenses detected, 34 offenses corrected
```

```
➜ $ rsgem version
0.1.0
```

```
➜ $ rsgem -v
0.1.0
```