### PR TITLE
Add configurations to .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,9 +4,18 @@ Style/Documentation:
 Layout/SpaceBeforeFirstArg:
   Exclude:
 
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - spec/**/*
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
 
 Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be an Integer or
@@ -57,6 +66,9 @@ Metrics/ParameterLists:
 
 Metrics/PerceivedComplexity:
   Max: 12
+
+Style/ExponentialNotation:
+  Enabled: true
 
 Style/FrozenStringLiteralComment:
   Enabled: true

--- a/lib/rsgem/support/rubocop.yml
+++ b/lib/rsgem/support/rubocop.yml
@@ -4,9 +4,18 @@ Style/Documentation:
 Layout/SpaceBeforeFirstArg:
   Exclude:
 
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - spec/**/*
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
 
 Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be an Integer or
@@ -57,6 +66,9 @@ Metrics/ParameterLists:
 
 Metrics/PerceivedComplexity:
   Max: 12
+
+Style/ExponentialNotation:
+  Enabled: true
 
 Style/FrozenStringLiteralComment:
   Enabled: true

--- a/rsgem.gemspec
+++ b/rsgem.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0.1'
   spec.add_development_dependency 'reek', '~> 5.6.0'
   spec.add_development_dependency 'rspec', '~> 3.9.0'
-  spec.add_development_dependency 'rubocop', '~> 0.80.0'
+  spec.add_development_dependency 'rubocop', '~> 0.82.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
 end


### PR DESCRIPTION
Resolves #43 

This PR adds the following configurations to the default rubocop file:

- Layout/SpaceAroundMethodCallOperator
- Lint/RaiseException
- Lint/StructNewOverride
- Style/ExponentialNotation