### PR TITLE
Feature/48 1 cache bundler dependencies in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
+    - name: Calculate variable dynamic values
+      id: dynamic_values
+      run: |
+        echo "::set-output name=installed_ruby_version::$(ruby -e 'print RUBY_VERSION')"
+        echo "::set-output name=cacheTimeAnchor::$(ruby -e 'require %Q{date}; cacheExpirationSeconds = 60*60*24; print (Time.now.to_i / cacheExpirationSeconds)')"
     - name: Update ruby gems when testing with Ruby 2.4.x
       if: startsWith(matrix.ruby_version, '2.4')
       run: |
@@ -26,12 +31,25 @@ jobs:
         ./cc-test-reporter before-build
       env:
         CC_TEST_REPORTER_ID: 0caaf0c68cbf5597ac7eb5207944c878a0b3fba46dbfa113093b861f2d25762e
-    - name: Build and test
+    - name: Install and config bundler
       run: |
         gem install bundler:1.17.3
-        bundle update
+    - name: Generate 'Gemfile.lock' before caching gems
+      run: |
+        bundle lock --update
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-ruby_v${{ steps.dynamic_values.outputs.installed_ruby_version }}-time_${{steps.dynamic_values.outputs.cacheTimeAnchor}}-gems-${{ hashFiles('**/Gemfile.lock') }}
+    - name: Install dependencies
+      run: |
+        bundle config set path 'vendor/bundle'
         bundle install --jobs 4 --retry 3
+    - name: Run code analysis
+      run: |
         bundle exec rake code_analysis
+    - name: Run tests
+      run: |
         bundle exec rspec
     - name: Report to CodeClimate
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+* Cache bundler directory for 24hs in Github Actions
+
+    *Martín Rubí*
+
 # 0.3.0
 
 * Add task to replace system user name in LICENSE.txt with Rootstrap name

--- a/lib/rsgem/support/github_actions.yml
+++ b/lib/rsgem/support/github_actions.yml
@@ -15,6 +15,11 @@ jobs:
       uses: actions/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
+    - name: Calculate variable dynamic values
+      id: dynamic_values
+      run: |
+        echo "::set-output name=installed_ruby_version::$(ruby -e 'print RUBY_VERSION')"
+        echo "::set-output name=cacheTimeAnchor::$(ruby -e 'require %Q{date}; cacheExpirationSeconds = 60*60*24; print (Time.now.to_i / cacheExpirationSeconds)')"
     - name: Download CodeClimate reporter
       run: |
         curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
@@ -22,12 +27,25 @@ jobs:
         ./cc-test-reporter before-build
       env:
         CC_TEST_REPORTER_ID: get_a_test_reporter_id_from_code_climate
-    - name: Build and test
+    - name: Install and config bundler
       run: |
         gem install bundler:1.17.3
-        bundle update
+    - name: Generate 'Gemfile.lock' before caching gems
+      run: |
+        bundle lock --update
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-ruby_v${{ steps.dynamic_values.outputs.installed_ruby_version }}-time_${{steps.dynamic_values.outputs.cacheTimeAnchor}}-gems-${{ hashFiles('**/Gemfile.lock') }}
+    - name: Install dependencies
+      run: |
+        bundle config set path 'vendor/bundle'
         bundle install --jobs 4 --retry 3
+    - name: Run code analysis
+      run: |
         bundle exec rake code_analysis
+    - name: Run tests
+      run: |
         bundle exec rspec
     - name: Report to CodeClimate
       run: |


### PR DESCRIPTION
### Summary

Cache gems during GitHub Actions

**Issue #48**
This PR implements partially [Add cache config for Github Actions #48](https://github.com/rootstrap/rsgem/issues/48)
Bundle cache in rsgem project is tested. I didn't test it in the generated scripts.

### Other Information

- Create a `Generate 'Gemfile.lock' before caching gems` step to generate `Gemfile.lock` file without downloading nor installing the gems
- Add an `actions/cache@v2` step to cache gems. Use `vendor/bundle` as the bundler path.
- In the cache directory key include a hash of the `Gemfile.lock` to refresh the cache when dependencies change
- In the cache directory key include the ruby version number vX.Y.Z as bundler uses a different directory for each Ruby version
- In the cache directory key include a timestamp with an expiration of 1 day. That is achieved by including the number of seconds since epoc at the time of running CI divided the expiration time expressed in seconds
```ruby
require 'date'
cacheExpirationSeconds = 60*60*24
cacheTimeAnchor = Time.now.to_i/cacheExpirationSeconds
```
- Split step `Build and test` into 3 different steps to benchmark each execution time
- Create step `Install dependencies` to install gems. Use  `vendor/bundle` as the bundler path
- Create step `Test code` to run `code_analysis`
- Create step `Run tests` to run `rspec`