### PR TITLE
Update development dependencies to latest versions

### DIFF
--- a/lib/rsgem/ci_providers/base.rb
+++ b/lib/rsgem/ci_providers/base.rb
@@ -5,7 +5,7 @@ module RSGem
     class Base
       attr_reader :config_file_destination, :config_file_source, :name, :display_name
 
-      def initialize(config_file_source: nil, config_file_destination: nil, display_name:, name:)
+      def initialize(display_name:, name:, config_file_source: nil, config_file_destination: nil)
         @config_file_source = config_file_source
         @config_file_destination = config_file_destination
         @display_name = display_name

--- a/lib/rsgem/tasks/run_rubocop.rb
+++ b/lib/rsgem/tasks/run_rubocop.rb
@@ -5,7 +5,7 @@ module RSGem
     class RunRubocop < Base
       def perform
         puts "\tRubocop:"
-        @output = `cd #{context.folder_path} && bundle exec rubocop -a`
+        @output = `cd #{context.folder_path} && bundle exec rubocop -A`
         puts "\t\t#{last_line}"
       end
 

--- a/rsgem.gemspec
+++ b/rsgem.gemspec
@@ -24,10 +24,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'dry-cli', '~> 0.6.0'
-  spec.add_development_dependency 'pry', '~> 0.13.0'
+  spec.add_development_dependency 'pry', '~> 0.13.1'
   spec.add_development_dependency 'rake', '~> 13.0.1'
-  spec.add_development_dependency 'reek', '~> 5.6.0'
+  spec.add_development_dependency 'reek', '~> 6.0.2'
   spec.add_development_dependency 'rspec', '~> 3.9.0'
-  spec.add_development_dependency 'rubocop', '~> 0.82.0'
+  spec.add_development_dependency 'rubocop', '~> 1.0.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
 end


### PR DESCRIPTION
### Summary

Addresses #45 
Updated development dependencies to latest versions:

- pry **0.13.0** to **0.13.1**
- reek **5.6.0** to **6.0.2**
- rubocop **0.82.0** to **1.0.0**

Note: simplecov was not updated since codeclimate still doesn't support newer versions

Closes #45 